### PR TITLE
Fix CI failures

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,3 +13,6 @@ display_and_debug = []
 
 [dependencies]
 thiserror = { version = "2.0.14", default-features = false }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/common/src/accounts/mod.rs
+++ b/common/src/accounts/mod.rs
@@ -1,0 +1,43 @@
+// use core::fmt;
+
+// pub struct Account {
+//     fee_payer: bool,
+//     account_type: AccountType,
+//     owner: [u8; 32],
+// }
+
+// #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+// pub enum AccountType {
+//     User,
+//     Native,
+//     PDA,
+//     // For PDA Data
+//     Data(Data),
+//     Program,
+//     Mint,
+//     Token,
+//     AssociatedTokenAccount,
+//     Vote,
+//     Stake,
+// }
+
+// impl fmt::Display for AccountType {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(
+//             f,
+//             "{}",
+//             match self {
+//                 Self::Native => " Account",
+//                 Self::PDA => "Program Derived Account",
+//                 Self::Program => "Executable Program Account",
+//             }
+//         )
+//     }
+// }
+
+// // Fee payer must be owned by the Solana Program
+// // Program must be owned by the BPF loader
+
+// pub struct Data {
+//     version: Semver,
+// }

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -1,5 +1,6 @@
 /// Helper method instead of using the longer fn() -> Result<T, [HullSvmError]>
 /// you can use fn() -> [HullSvmResult]<T>
+#[allow(rustdoc::invalid_html_tags)]
 pub type HullSvmResult<T> = Result<T, HullSvmError>;
 
 /// The error handler used across Hull SVM framework crates

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,7 +2,6 @@
 #![forbid(missing_docs)]
 
 //! Module for common utilities for the Hull SVM framework.
-//!
 
 mod semver;
 pub use semver::*;

--- a/common/src/semver.rs
+++ b/common/src/semver.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "display_and_debug")]
 use core::fmt;
 
 use crate::HullSvmError;
@@ -67,6 +68,7 @@ impl Semver {
     const ALPHA_RANK: u8 = 0;
     const BETA_RANK: u8 = 1;
     const RELEASE_CANDIDATE_RANK: u8 = 2;
+    #[cfg(feature = "ordering")]
     const STABLE_RANK: u8 = 3;
     const NO_RANK: u8 = 4;
     const MAJOR_INDEX: usize = 0;
@@ -333,7 +335,10 @@ impl TryFrom<&[u8]> for Semver {
     }
 }
 
-/// Use [SemverTextBuffer] to convert [Semver] to a byte slice that can be
+/// Use
+#[cfg_attr(feature = "display_and_debug", doc = "[SemverTextBuffer]")]
+#[cfg_attr(not(feature = "display_and_debug"), doc = "`SemverTextBuffer`")]
+/// to convert [Semver] to a byte slice that can be
 /// converted to a valid UTF-8 stack allocated string `(&str)`
 /// ### Usage
 /// ```rust
@@ -349,7 +354,7 @@ pub struct SemverTextBuffer([u8; Self::TEXT_BUFFER_SIZE]);
 
 #[cfg(feature = "display_and_debug")]
 impl SemverTextBuffer {
-    const SEPERATOR_CHAR_SIZE: usize = 1;
+    const SEPARATOR_CHAR_SIZE: usize = 1;
     const U8_MAX_CHARS: usize = 3;
     const MAX_UNSTABLE_CHAR_SIZE: usize = 5;
     const CHAR_BUFFER: [u8; crate::Utils::ASCII_DIGIT_BUFFER_SIZE] =
@@ -365,7 +370,7 @@ impl SemverTextBuffer {
 
     const TEXT_BUFFER_SIZE: usize = Self::MARKER_LEN
         + (SemverTextBuffer::U8_MAX_CHARS * 4)
-        + (SemverTextBuffer::SEPERATOR_CHAR_SIZE * 4)
+        + (SemverTextBuffer::SEPARATOR_CHAR_SIZE * 4)
         + SemverTextBuffer::MAX_UNSTABLE_CHAR_SIZE;
 
     /// Instantiate a new zero filled buffer
@@ -411,7 +416,7 @@ impl SemverTextBuffer {
             valid_buffer_length += marker;
             if separator {
                 self.0[valid_buffer_length] = b'.';
-                valid_buffer_length += Self::SEPERATOR_CHAR_SIZE;
+                valid_buffer_length += Self::SEPARATOR_CHAR_SIZE;
             }
         };
 
@@ -426,13 +431,13 @@ impl SemverTextBuffer {
             |value: Option<u8>, char_buffer: &mut [u8; 3], chars: &[u8], char_size: usize| {
                 if let Some(inner_value) = value {
                     self.0[valid_buffer_length] = b'-';
-                    valid_buffer_length += Self::SEPERATOR_CHAR_SIZE;
+                    valid_buffer_length += Self::SEPARATOR_CHAR_SIZE;
 
                     self.0[valid_buffer_length..valid_buffer_length + char_size]
                         .copy_from_slice(chars);
                     valid_buffer_length += char_size;
                     self.0[valid_buffer_length] = b'.';
-                    valid_buffer_length += Self::SEPERATOR_CHAR_SIZE;
+                    valid_buffer_length += Self::SEPARATOR_CHAR_SIZE;
 
                     let inner_value_marker = Utils::u8_to_ascii_digits(inner_value, char_buffer);
 


### PR DESCRIPTION
- Fix unclosed HTML tag in errors.rs
- Add `--all-features` to docs.rs workflow to enable `SemverTextBuffer`
- Fix typo `SEPERATOR` to `SEPARATOR`
- `core::fmt` should be feature gated by `display_and_debug` feature
- feature gate `STABLE_RANK` constant under `ordering` feature